### PR TITLE
Added the ability to save stock levels.

### DIFF
--- a/App.axaml.cs
+++ b/App.axaml.cs
@@ -1,3 +1,5 @@
+using System;
+using System.ComponentModel.Design;
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Data.Core;
@@ -5,6 +7,7 @@ using Avalonia.Data.Core.Plugins;
 using System.Linq;
 using Avalonia.Markup.Xaml;
 using Microsoft.Extensions.DependencyInjection;
+using Paints.Services;
 using Paints.ViewModels;
 using Paints.Views;
 
@@ -12,6 +15,10 @@ namespace Paints;
 
 public partial class App : Application
 {
+    public new static App? Current => (App?)Application.Current;
+
+    public IServiceProvider? ServiceProvider { get; private set; }
+    
     public override void Initialize()
     {
         AvaloniaXamlLoader.Load(this);
@@ -19,6 +26,10 @@ public partial class App : Application
 
     public override void OnFrameworkInitializationCompleted()
     {
+        var serviceContainer = new ServiceContainer();
+        serviceContainer.AddService(typeof(IFileService), new FileService());
+        ServiceProvider = serviceContainer;
+        
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
             // Avoid duplicate validations from both Avalonia and the CommunityToolkit. 
@@ -29,7 +40,7 @@ public partial class App : Application
                 DataContext = new MainWindowViewModel(),
             };
         }
-
+        
         base.OnFrameworkInitializationCompleted();
     }
 

--- a/Models/Paint.cs
+++ b/Models/Paint.cs
@@ -3,14 +3,21 @@ using Avalonia.Media;
 
 namespace Paints.Models;
 
-public class Paint(string name, string brand, Color colour) : IEquatable<Paint>
+public record struct PaintColour(byte R, byte G, byte B, byte A)
 {
-    public Paint() : this( "" , "" , Colors.Black)
+    public PaintColour(byte R, byte G, byte B) : this(R, G, B, 255)
+    {
+    }
+}
+
+public class Paint(string name, string brand, PaintColour colour) : IEquatable<Paint>
+{
+    public Paint() : this( "" , "" , new PaintColour(0, 0, 0))
     {}
 
     public string Name { get; set; } = name;
     public string Brand { get; set; } = brand;
-    public Color Colour { get; set; } = colour;
+    public PaintColour Colour { get; set; } = colour;
 
     public bool Equals(Paint? other) => other != null && Name == other.Name;
 }

--- a/Models/Paint.cs
+++ b/Models/Paint.cs
@@ -14,9 +14,3 @@ public class Paint(string name, string brand, Color colour) : IEquatable<Paint>
 
     public bool Equals(Paint? other) => other != null && Name == other.Name;
 }
-
-public class PaintStock(Paint paint, uint stock = 0)
-{
-    public Paint Paint { get; set; } = paint;
-    public uint Stock { get; set; } = stock;
-}

--- a/Models/PaintList.cs
+++ b/Models/PaintList.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace Paints.Models;
+
+public class PaintStock(Paint paint, uint stock = 0)
+{
+    public Paint Paint { get; set; } = paint;
+    public uint Stock { get; set; } = stock;
+}
+
+public class PaintList : Dictionary<string, PaintStock>;

--- a/Services/IFileService.cs
+++ b/Services/IFileService.cs
@@ -1,0 +1,32 @@
+using System.IO;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Paints.Models;
+
+namespace Paints.Services;
+
+public interface IFileService
+{
+    public Task SavePaintList(PaintList list);
+    public Task<PaintList?> LoadPaintList();
+}
+
+public class FileService : IFileService
+{
+    public string FilePath => "~/.local/share/paints.json";
+
+    public async Task SavePaintList(PaintList list)
+    {
+        await using var fileStream = File.Create(FilePath);
+        
+        await JsonSerializer.SerializeAsync<PaintList>(fileStream, list);
+    }
+
+    public async Task<PaintList?> LoadPaintList()
+    {
+        await using var fileStream = File.Create(FilePath);
+        var value = await JsonSerializer.DeserializeAsync<PaintList>(fileStream);
+
+        return value;
+    }
+}

--- a/Services/IFileService.cs
+++ b/Services/IFileService.cs
@@ -35,7 +35,7 @@ public class FileService : IFileService
         if (!File.Exists(FilePath))
             return null;
         
-        await using var fileStream = File.Create(FilePath);
+        await using var fileStream = File.Open(FilePath, FileMode.Open);
         var value = await JsonSerializer.DeserializeAsync<PaintList>(fileStream);
 
         return value;

--- a/Services/IFileService.cs
+++ b/Services/IFileService.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Text.Json;
 using System.Threading.Tasks;
@@ -13,10 +14,15 @@ public interface IFileService
 
 public class FileService : IFileService
 {
-    public string FilePath => "~/.local/share/paints.json";
+    private static string FilePath => Path.Combine(DataDirectory, "stock.json");
 
+    private static string DataDirectory =>
+        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "paints");
+    
     public async Task SavePaintList(PaintList list)
     {
+        EnsureDirectoryExists();
+        
         await using var fileStream = File.Create(FilePath);
         
         await JsonSerializer.SerializeAsync<PaintList>(fileStream, list);
@@ -24,9 +30,20 @@ public class FileService : IFileService
 
     public async Task<PaintList?> LoadPaintList()
     {
+        EnsureDirectoryExists();
+
+        if (!File.Exists(FilePath))
+            return null;
+        
         await using var fileStream = File.Create(FilePath);
         var value = await JsonSerializer.DeserializeAsync<PaintList>(fileStream);
 
         return value;
+    }
+
+    private static void EnsureDirectoryExists()
+    {
+        if (!Directory.Exists(DataDirectory))
+            Directory.CreateDirectory(DataDirectory);
     }
 }

--- a/ViewModels/InfoPageViewModel.cs
+++ b/ViewModels/InfoPageViewModel.cs
@@ -18,7 +18,11 @@ public partial class InfoPageViewModel(PaintViewModel? paint, PaintList paintSto
 
     public PaintList PaintStocks
     {
-        set { _paintStocks = value; }
+        set
+        {
+            _paintStocks = value;
+            OnPropertyChanged(nameof(InStock));
+        }
     }
     
     public uint InStock
@@ -28,7 +32,7 @@ public partial class InfoPageViewModel(PaintViewModel? paint, PaintList paintSto
             if (Paint == null)
                 return 0;
             
-            if (!paintStocks.TryGetValue(Paint.Name, out var value))
+            if (!_paintStocks.TryGetValue(Paint.Name, out var value))
                 return 0;
             return value.Stock;
         }

--- a/ViewModels/InfoPageViewModel.cs
+++ b/ViewModels/InfoPageViewModel.cs
@@ -16,6 +16,11 @@ public partial class InfoPageViewModel(PaintViewModel? paint, PaintList paintSto
 
     private PaintList _paintStocks = paintStocks;
 
+    public PaintList PaintStocks
+    {
+        set { _paintStocks = value; }
+    }
+    
     public uint InStock
     {
         get

--- a/ViewModels/InfoPageViewModel.cs
+++ b/ViewModels/InfoPageViewModel.cs
@@ -9,12 +9,12 @@ using Paints.Views;
 
 namespace Paints.ViewModels;
 
-public partial class InfoPageViewModel(PaintViewModel? paint, Dictionary<string, PaintStock> paintStocks) : ViewModelBase
+public partial class InfoPageViewModel(PaintViewModel? paint, PaintList paintStocks) : ViewModelBase
 {
     [ObservableProperty]
     private PaintViewModel? _paint = paint;
 
-    private Dictionary<string, PaintStock> _paintStocks = paintStocks;
+    private PaintList _paintStocks = paintStocks;
 
     public uint InStock
     {

--- a/ViewModels/ListPageViewModel.cs
+++ b/ViewModels/ListPageViewModel.cs
@@ -10,7 +10,15 @@ namespace Paints.ViewModels;
 public class ListPageViewModel(IEnumerable<PaintStock> paints) : ViewModelBase
 {
     private IEnumerable<PaintStock> _paints = paints; 
-
+    
+    public IEnumerable<PaintStock> PaintModels
+    {
+        set
+        {
+            _paints = value; 
+            OnPropertyChanged(nameof(Paints));
+        }
+    }
     public IEnumerable<PaintViewModel> Paints => _paints.Select(PaintViewModelFactory);
     
     public IRelayCommand<PaintViewModel>? SelectPaintCommand { get; set; }

--- a/ViewModels/MainWindowViewModel.cs
+++ b/ViewModels/MainWindowViewModel.cs
@@ -17,7 +17,7 @@ public partial class MainWindowViewModel : ViewModelBase
     }
 
     private Page _currentPage = Page.List;
-    private Dictionary<string, PaintStock> _paints = []; 
+    private PaintList _paints = []; 
     
     // pages
     private ListPageViewModel _listPageViewModel;

--- a/ViewModels/MainWindowViewModel.cs
+++ b/ViewModels/MainWindowViewModel.cs
@@ -1,10 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Avalonia.Media;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Microsoft.Extensions.DependencyInjection;
 using Paints.Models;
+using Paints.Services;
 
 namespace Paints.ViewModels;
 
@@ -49,6 +52,32 @@ public partial class MainWindowViewModel : ViewModelBase
                 return _listPageViewModel;
             return _infoPageViewModel;
         }
+    }
+
+    [RelayCommand]
+    private async Task Save()
+    {
+        var fileService = App.Current?.ServiceProvider?.GetService<IFileService>();
+        if (fileService == null)
+            return;
+
+        await fileService.SavePaintList(_paints);
+    }
+
+    [RelayCommand]
+    private async Task Load()
+    {
+        var fileService = App.Current?.ServiceProvider?.GetService<IFileService>();
+        if (fileService == null)
+            return;
+
+        var paints = await fileService.LoadPaintList();
+        if (paints == null)
+            return;
+
+        _paints = paints;
+        _infoPageViewModel.PaintStocks = paints;
+        _listPageViewModel.PaintModels = paints.Values;
     }
     
     private void SelectPaint(PaintViewModel? paint)

--- a/ViewModels/MainWindowViewModel.cs
+++ b/ViewModels/MainWindowViewModel.cs
@@ -28,10 +28,10 @@ public partial class MainWindowViewModel : ViewModelBase
 
     public MainWindowViewModel()
     {
-        AddPaint(new Paint("Whimsical White", "Eris", Colors.White));
-        AddPaint(new Paint("Bulbous Blue", "Eris", Colors.Blue));
-        AddPaint(new PaintStock(new Paint("Silly Salamander", "Eris", Colors.LightPink), 1));
-        AddPaint(new Paint("Goose Gray", "Eris", Colors.Gray));
+        AddPaint(new Paint("Whimsical White", "Eris", new PaintColour(255, 255, 255)));
+        AddPaint(new Paint("Bulbous Blue", "Eris", new PaintColour(0, 0, 255)));
+        AddPaint(new PaintStock(new Paint("Silly Salamander", "Eris", new PaintColour(255, 200, 200)), 1));
+        AddPaint(new Paint("Goose Gray", "Eris", new PaintColour(155, 155, 155)));
 
         _listPageViewModel = new ListPageViewModel(_paints.Values)
         {

--- a/ViewModels/PaintViewModel.cs
+++ b/ViewModels/PaintViewModel.cs
@@ -43,7 +43,22 @@ public class PaintViewModel(Paint paint) : ViewModelBase
 
     public Color Colour
     {
-        get => Paint.Colour;
-        set => SetProperty(Paint.Colour, value, Paint, (m, v) => m.Colour = value);
-    }        
+        get => ConvertColour(Paint.Colour);
+        set => SetProperty(
+            ConvertColour(Paint.Colour), 
+            value, 
+            Paint, 
+            (m, v) => m.Colour = ConvertColour(value)
+        );
+    }
+
+    private static Color ConvertColour(PaintColour colour)
+    {
+        return new Color(colour.A, colour.R, colour.G, colour.B);
+    }
+
+    private static PaintColour ConvertColour(Color colour)
+    {
+        return new PaintColour(colour.R, colour.G, colour.B, colour.A);
+    }
 }

--- a/Views/MainWindow.axaml
+++ b/Views/MainWindow.axaml
@@ -16,7 +16,13 @@
         <vm:MainWindowViewModel/>
     </Design.DataContext>
    
-    <ContentControl Content="{Binding CurrentPage}"/>
-    <!-- <TransitioningContentControl></TransitioningContentControl> -->
-    <!-- <cc:ListPageView /> -->
+    <DockPanel>
+        <Menu DockPanel.Dock="Top">
+            <MenuItem Header="File">
+                <MenuItem Header="Save" Command="{Binding SaveCommand}"/>
+                <MenuItem Header="Load" Command="{Binding LoadCommand}"/>
+            </MenuItem>
+        </Menu>
+        <ContentControl Content="{Binding CurrentPage}"/>
+    </DockPanel>
 </Window>

--- a/paints.csproj
+++ b/paints.csproj
@@ -10,7 +10,6 @@
 
   <ItemGroup>
     <AvaloniaResource Include="Assets\**" />
-    <Folder Include="Services\" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Added the ability to save stock levels.

Saves to a json file in AppData. (`%AppData%\Roaming\paints\stock.json` on windows, `~/.config/paints/stock.json` on linux).

This JSON file is mini-fied as per the default output of `System.Json`.

Closes #3.